### PR TITLE
Change website middle to aqua

### DIFF
--- a/src/config/brand.json
+++ b/src/config/brand.json
@@ -29,7 +29,7 @@
     },
     "theme": {
       "name": "aqua",
-      "frameName": "green"
+      "frameName": "aqua"
     }
   }
 }


### PR DESCRIPTION
Update the embedded fury.bot frame theme to aqua to change the center panel color.

---
<a href="https://cursor.com/background-agent?bcId=bc-3dc004e9-be95-4534-a4d3-722eddbcd10f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3dc004e9-be95-4534-a4d3-722eddbcd10f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

